### PR TITLE
Only treat `N` or `n` as a valid reply

### DIFF
--- a/zap
+++ b/zap
@@ -18,6 +18,8 @@ function remove()
       read -p "Remove $path? " -r
       if [[ $REPLY =~ ^[Yy]$ ]]; then
         $cmd -r "$path"
+      elif [[ ! $REPLY =~ ^[Nn]$ ]]; then
+        remove "$path"
       fi
     fi
   done


### PR DESCRIPTION
Currently if you type anything besides `Y` or `y`, zap will go to the
next file, with this change you have to explicitly type `N` or `n`
instead so that you cannot accidentally hit enter and skip a file.